### PR TITLE
Change the hardcoded color space selection of the texture to generic handling

### DIFF
--- a/src/hydra/utils/texture.py
+++ b/src/hydra/utils/texture.py
@@ -23,7 +23,7 @@ def get_or_make_image(size: 'tuple[int,int]', name: str)->tuple[bpy.types.Image,
 		img = bpy.data.images[name]
 		updated = True
 	
-	img.colorspace_settings.name = "Non-Color"
+	img.colorspace_settings.is_data = True
 
 	if tuple(img.size) != size:
 		img.scale(size[0], size[1])


### PR DESCRIPTION
When using a custom OCIO config the addon throws an error since the color space of the generated texture is hardcoded to "Non-Color" while sometimes in a config is described as "Generic Data, none, Raw, Utility - Raw, etc". This change now refers to the "role: data" of the config file, which better handles the name and possible aliases.